### PR TITLE
Fix uart write answer reading

### DIFF
--- a/bno055/connectors/uart.py
+++ b/bno055/connectors/uart.py
@@ -150,7 +150,7 @@ class UART(Connector):
 
         try:
             self.serialConnection.write(buf_out)
-            buf_in = bytearray(self.serialConnection.read())
+            buf_in = bytearray(self.serialConnection.read(2))
         except Exception:  # noqa: B902
             return False
 


### PR DESCRIPTION
  [PR#52](https://github.com/flynneva/bno055/pull/52) broke the UART write function in uart.py, this small edit fixes that. More info here: https://github.com/flynneva/bno055/pull/52#discussion_r1081186341