### PR TITLE
Update package.xml to include python3-smbus dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,7 @@
 
   <!-- For serial UART communication : -->
   <depend>python3-serial</depend>
+  <depend>python3-smbus</depend>
   <!--ROS Client Libraries for Python:-->
   <exec_depend>rclpy</exec_depend>
   <!-- Publishing standard message types: -->


### PR DESCRIPTION
This adds the `python3-smbus` requirement to the `package.xml`, which allows all dependencies to be installed with `rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -yr` on a workspace. We hit a `smbus` dependency error when trying to compile on a Jetson board, which didn't have `python3-smbus` installed, and this fixed the issue for us. Hopefully it will fix it for others too!