### PR TITLE
fix build error on foxy that caused by typo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ package_name = 'bno055'
 
 setup(
     name=package_name,
-    version='0.4.1.',
+    version='0.4.1',
     # find sub-packages automatically in order to allow sub-modules, etc. to be imported:
     # packages=[package_name],
     packages=find_packages(exclude=['test']),


### PR DESCRIPTION
Basic fix to error that causes stderr on ROS Foxy.

![image](https://user-images.githubusercontent.com/63360489/220431432-97831e6a-02a8-4de7-bbff-1fa666575d46.png)
